### PR TITLE
Allow built-in SAT solver and external CM5 solver to use multiple threads

### DIFF
--- a/src/configdata.hpp
+++ b/src/configdata.hpp
@@ -61,6 +61,7 @@ struct ConfigData {
     uint32_t xlDeg;
     uint64_t numConfl_inc = 10000;
     uint64_t numConfl_lim = 100000;
+    unsigned int numThreads = 1;
     bool stopOnSolution = false;
     bool learnSolution = false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,8 @@ void parseOptions(int argc, char* argv[])
      "Conflict inc for built-in SAT solver.")
     ("satlim", po::value<uint64_t>(&config.numConfl_lim)->default_value(config.numConfl_lim),
      "Conflict limit for built-in SAT solver.")
+    ("threads,t", po::value<unsigned int>(&config.numThreads)->default_value(config.numThreads),
+     "Number of threads to use for SAT solver (same value is used for built-in and external).")
     ;
 
 #ifdef SATSOLVE_ENABLED
@@ -260,7 +262,8 @@ void parseOptions(int argc, char* argv[])
              << "c EL simp (s = " << config.ELsample << "): " << !config.noEL
              << endl
              << "c SAT simp (" << config.numConfl_inc << ':'
-             << config.numConfl_lim << "): " << !config.noSAT << endl
+             << config.numConfl_lim << "): " << !config.noSAT
+             << " using " << config.numThreads << " threads" << endl
              << "c Stop simplifying if SAT finds solution? "
              << (config.stopOnSolution ? "Yes" : "No") << endl
              << "c Paranoid: " << config.paranoid << endl
@@ -630,7 +633,7 @@ void solve_by_sat(const ANF* anf, const vector<Clause>& cutting_clauses,
                   const ANF* orig_anf)
 {
     CNF* cnf = anf_to_cnf(anf, cutting_clauses);
-    SATSolve solver(config.verbosity, config.paranoid, config.solverExe);
+    SATSolve solver(config.verbosity, config.paranoid, config.solverExe, config.numThreads);
     vector<lbool> sol = solver.solveCNF(orig_anf, *anf, *cnf);
     std::ofstream ofs;
     ofs.open(config.solutionOutput.c_str());

--- a/src/satsolve.cpp
+++ b/src/satsolve.cpp
@@ -32,11 +32,12 @@ using std::cerr;
 using std::endl;
 
 SATSolve::SATSolve(const int _verbosity, const bool _testsolution,
-                   string _solverExecutable)
+                   string _solverExecutable, const int _numThreads)
     : satisfiable(l_Undef),
       solverExecutable(_solverExecutable),
       verbosity(_verbosity),
-      testsolution(_testsolution)
+      testsolution(_testsolution),
+      numThreads(_numThreads)
 {
 }
 
@@ -72,8 +73,8 @@ void SATSolve::createChildProcess()
         close(out[0]);
 
         // Over-write the child process with the binary
-        execl(solverExecutable.c_str(), solverExecutable.c_str(), "--polar" , "false",
-                (char *) NULL);
+        execl(solverExecutable.c_str(), solverExecutable.c_str(), "--polar" , "false", 
+              "-t", std::to_string(numThreads).c_str(), (char *) NULL);
 
         //If we couldn't overwrite it, it means there is a failure
         int err_save = errno;

--- a/src/satsolve.hpp
+++ b/src/satsolve.hpp
@@ -63,7 +63,7 @@ class SATSolve
 {
    public:
     SATSolve(const int verbosity, const bool testsolution,
-             string solverExecutable);
+             string solverExecutable, const int numThreads);
 
     vector<lbool> solveCNF(const ANF* orig_anf, const ANF& anf, const CNF& cnf);
     const vector<lbool>& getSolution() const
@@ -93,6 +93,7 @@ class SATSolve
     string solverExecutable;
     int verbosity;
     bool testsolution;
+    int numThreads;
 };
 
 #endif //SATSOLVE__H

--- a/src/simplifybysat.cpp
+++ b/src/simplifybysat.cpp
@@ -58,6 +58,7 @@ SimplifyBySat::SimplifyBySat(const CNF& _cnf, const ConfigData& _config)
     // Create SAT solver
     solver = new CMSat::SATSolver();
     solver->set_verbosity(config.verbosity >= 5 ? 1 : 0);
+    solver->set_num_threads(config.numThreads);
 }
 
 SimplifyBySat::~SimplifyBySat()


### PR DESCRIPTION
Hi Mate,

On some large problems, I've found that letting the built-in SAT solver and the call to cryptominisat5 use multiple threads leads to finding the solution faster (in wall clock time). This PR adds a command line option to specify the number of threads for these solvers to use.  Please merge if you think this is useful, or feel free to reject if it is not.

Thanks
Avinash