### PR TITLE
Use absolute include for m4ri headers

### DIFF
--- a/src/gaussjordan.hpp
+++ b/src/gaussjordan.hpp
@@ -28,7 +28,7 @@ SOFTWARE.
 #include <unordered_map>
 
 #include "anf.hpp"
-#include "m4ri.h"
+#include <m4ri/m4ri.h>
 #include "time_mem.h"
 
 using std::cout;


### PR DESCRIPTION
When manually setting the location of the m4ri library during a bosphorus build, the relative path that was used for the m4ri header inclusion was causing errors.

```
cmake -DSTATICCOMPILE=ON \
        -DM4RI_LIBRARIES=../m4ri/build/lib/libm4ri.a \
        -DM4RI_INCLUDE_DIRS=../m4ri/build/include
...
File not found: m4ri.h
```

It is much safer to use an 'absolute' include here, which will work on all situations.

I've verified this PR to work with scenario described above, as well as the default build instructions from the bosphorus readme.md. 
The Dockerfile also builds correctly with absolute includes.