### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 bosphorus.kdev4
+.venv

--- a/README.md
+++ b/README.md
@@ -255,12 +255,22 @@ ln -s ../utils/* .
 ```
 
 ## Testing
-Must have [LLVM lit](https://github.com/llvm-mirror/llvm/tree/master/utils/lit) and [stp OutputCheck](https://github.com/stp/OutputCheck). Please install with:
+
+The test suite uses [LLVM lit](https://github.com/llvm-mirror/llvm/tree/master/utils/lit) and [stp OutputCheck](https://github.com/stp/OutputCheck). It's convenient to use a [Python virtual environment](https://docs.python.org/3/library/venv.html):
+
 ```
-pip install lit
-pip install OutputCheck
+cd bosphorus
+python3 -m venv .venv 
+source .venv/bin/activate
+pip install -r requirements.test.txt
 ```
-Run test suite via `lit bosphorus/tests`
+
+Now you can run the tests via:
+
+```
+lit tests
+```
+
 
 # Known issues
 - PolyBoRi cannot handle ring of sizes over approx 1 million (1048574). Do not run `bosphorus` on instances with over a million variables.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,2 @@
+lit==12.0.1
+OutputCheck==0.4.1

--- a/tests/anf_prop.anf
+++ b/tests/anf_prop.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1 + x2

--- a/tests/el.anf
+++ b/tests/el.anf
@@ -1,3 +1,3 @@
-c RUN: %solver --anfread %s --nodefault --elsimp --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 1 --xl 0 --sat 0 | %check %s.out
 x1 + x2 + x3
 x1*x2 + x2*x3 + 1

--- a/tests/fixed.anf
+++ b/tests/fixed.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1

--- a/tests/gj.anf
+++ b/tests/gj.anf
@@ -1,3 +1,3 @@
-c RUN: %solver --anfread %s --nodefault --gjsimp --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 1 --xl 0 --sat 0 | %check %s.out
 x1*x2 + x1 + x2
 x1*x2 + x1 + x3

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -7,6 +7,6 @@ config.suffixes = [".anf"]
 solverExecutable = "../build/bosphorus"
 config.substitutions.append(("%solver", solverExecutable))
 
-checkExecutable = "/usr/bin/OutputCheck"
+checkExecutable = "OutputCheck"
 checkArgs = "--comment='c'"
 config.substitutions.append(("%check", "{0} {1}".format(checkExecutable, checkArgs)))

--- a/tests/not_eaten.anf
+++ b/tests/not_eaten.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1

--- a/tests/not_eaten2.anf
+++ b/tests/not_eaten2.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1 + x2

--- a/tests/xl.anf
+++ b/tests/xl.anf
@@ -1,3 +1,3 @@
-c RUN: %solver --anfread %s --nodefault --xlsimp --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 1 --sat 0 | %check %s.out
 x1*x2 + x1 + 1
 x2*x3 + x3


### PR DESCRIPTION
Makes all 7 tests pass again by updating to the modern Bospherus syntax. Also some light QoL improvements.

```
(.venv) ➜  bosphorus git:(master) ✗ lit tests
-- Testing: 7 tests, 7 workers --
PASS: tests :: not_eaten2.anf (1 of 7)
PASS: tests :: gj.anf (2 of 7)
PASS: tests :: xl.anf (3 of 7)
PASS: tests :: fixed.anf (4 of 7)
PASS: tests :: not_eaten.anf (5 of 7)
PASS: tests :: el.anf (6 of 7)
PASS: tests :: anf_prop.anf (7 of 7)

Testing Time: 0.14s
  Passed: 7
```