### PR TITLE
Fix substitute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 bosphorus.kdev4
+.venv

--- a/README.md
+++ b/README.md
@@ -255,12 +255,22 @@ ln -s ../utils/* .
 ```
 
 ## Testing
-Must have [LLVM lit](https://github.com/llvm-mirror/llvm/tree/master/utils/lit) and [stp OutputCheck](https://github.com/stp/OutputCheck). Please install with:
+
+The test suite uses [LLVM lit](https://github.com/llvm-mirror/llvm/tree/master/utils/lit) and [stp OutputCheck](https://github.com/stp/OutputCheck). It's convenient to use a [Python virtual environment](https://docs.python.org/3/library/venv.html):
+
 ```
-pip install lit
-pip install OutputCheck
+cd bosphorus
+python3 -m venv .venv 
+source .venv/bin/activate
+pip install -r requirements.test.txt
 ```
-Run test suite via `lit bosphorus/tests`
+
+Now you can run the tests via:
+
+```
+lit tests
+```
+
 
 # Known issues
 - PolyBoRi cannot handle ring of sizes over approx 1 million (1048574). Do not run `bosphorus` on instances with over a million variables.

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,2 @@
+lit==12.0.1
+OutputCheck==0.4.1

--- a/src/anfutils.cpp
+++ b/src/anfutils.cpp
@@ -108,26 +108,26 @@ double BLib::do_sample_and_clone(const uint32_t verbosity,
     return log2uniquesz;
 }
 
-void BLib::subsitute(const BooleVariable& from_var, const BoolePolynomial& to_poly,
-               BoolePolynomial& poly)
+void BLib::substitute(const BooleVariable& from_var,
+                      const BoolePolynomial& to_poly, BoolePolynomial& poly)
 {
-  BoolePolynomial quotient = poly / from_var;
+    BoolePolynomial quotient = poly / from_var;
 
-  if( quotient.isZero() ) { // 
-      // `from_var` does not occur in `poly`, so just keep `poly` as it is.
-      return;
-  } else if (quotient.isOne()) { // just
-      // from_var == poly, so return the value of to_poly.
-      quotient *= to_poly;
-      swap(quotient, poly); // because we are returning poly
-  } else {
-      // build up the return value based on the quotient and the remainder
-      quotient *= to_poly;
-      for (const BooleMonomial& mono : poly) {
-          if (!mono.reducibleBy(from_var)) {
-              quotient += mono;
-          }
-      }
-      swap(quotient, poly); // because we are returning poly
-  }
+    if (quotient.isZero()) {
+        // `from_var` does not occur in `poly`, so just keep `poly` as it is.
+        return;
+    }
+
+    // Note: `quotient == 1` doesn't mean `poly == from_var`, just that `poly == from_var + r` for some remainder.
+
+    quotient *= to_poly;
+
+    if (!poly.isSingleton()) {
+        for (const BooleMonomial& mono : poly) {
+            if (!mono.reducibleBy(from_var)) {
+                quotient += mono;
+            }
+        }
+    }
+    swap(quotient, poly); // because we are returning poly
 }

--- a/src/anfutils.hpp
+++ b/src/anfutils.hpp
@@ -43,7 +43,7 @@ double do_sample_and_clone(const uint32_t verbosity,
                            std::vector<polybori::BoolePolynomial>& equations,
                            double log2size);
 
-void subsitute(const polybori::BooleVariable& from_var,
+void substitute(const polybori::BooleVariable& from_var,
                const polybori::BoolePolynomial& to_poly,
                polybori::BoolePolynomial& poly);
 

--- a/src/elimlin.cpp
+++ b/src/elimlin.cpp
@@ -134,7 +134,7 @@ bool BLib::elimLin(const ConfigData& config, const vector<BoolePolynomial>& eqs,
                     if (linear_idx == idx)
                         poly = 0; // replacing itself
                     else {
-                        subsitute(from_var, to_poly, poly);
+                        substitute(from_var, to_poly, poly);
                         BooleMonomial curr_used(poly.usedVariables());
                         BooleMonomial gcd = prev_used.GCD(curr_used);
                         prev_used /= gcd; // update remove list

--- a/tests/anf_prop.anf
+++ b/tests/anf_prop.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1 + x2

--- a/tests/el.anf
+++ b/tests/el.anf
@@ -1,3 +1,3 @@
-c RUN: %solver --anfread %s --nodefault --elsimp --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 1 --xl 0 --sat 0 | %check %s.out
 x1 + x2 + x3
 x1*x2 + x2*x3 + 1

--- a/tests/fixed.anf
+++ b/tests/fixed.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1

--- a/tests/gj.anf
+++ b/tests/gj.anf
@@ -1,3 +1,3 @@
-c RUN: %solver --anfread %s --nodefault --gjsimp --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 1 --xl 0 --sat 0 | %check %s.out
 x1*x2 + x1 + x2
 x1*x2 + x1 + x3

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -7,6 +7,6 @@ config.suffixes = [".anf"]
 solverExecutable = "../build/bosphorus"
 config.substitutions.append(("%solver", solverExecutable))
 
-checkExecutable = "/usr/bin/OutputCheck"
+checkExecutable = "OutputCheck"
 checkArgs = "--comment='c'"
 config.substitutions.append(("%check", "{0} {1}".format(checkExecutable, checkArgs)))

--- a/tests/not_eaten.anf
+++ b/tests/not_eaten.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1

--- a/tests/not_eaten2.anf
+++ b/tests/not_eaten2.anf
@@ -1,2 +1,2 @@
-c RUN: %solver --anfread %s --nodefault --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 0 --sat 0 | %check %s.out
 x1 + x2

--- a/tests/substitute_carefully.anf
+++ b/tests/substitute_carefully.anf
@@ -1,0 +1,10 @@
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 1 --xl 0 --sat 0 | %check %s.out
+c
+c A bug in Bosphorus' variable substitution caused `x(1)` to be incorrectly simplified to 0.
+c This test verifies that doesn't happen anymore.
+c
+
+x(0)*x(7) + x(7)
+x(1) + x(5) + x(7)
+x(2) + x(0)
+x(3) + x(0) + 1

--- a/tests/substitute_carefully.anf.out
+++ b/tests/substitute_carefully.anf.out
@@ -1,0 +1,1 @@
+c CHECK-NOT: ^x\(1\)$

--- a/tests/xl.anf
+++ b/tests/xl.anf
@@ -1,3 +1,3 @@
-c RUN: %solver --anfread %s --nodefault --xlsimp --printfinal | %check %s.out
+c RUN: %solver --anfread %s --anfwrite /dev/stdout --el 0 --xl 1 --sat 0 | %check %s.out
 x1*x2 + x1 + 1
 x2*x3 + x3


### PR DESCRIPTION
Recently the `substitute` function was fixed to handle an edge case when the object polynomial was a singleton not containing the subject variable (see [#24], [#25]). As far as I can tell that fix is correct for the stated case.

Unfortunately the fix introduced a bug where if the polynomial _did_ contain `from_var` as a term of its own, all other monomials if any were thrown away.

Example:

1. in: `x(0)*x(7) + x(1) + x(5)`
2. `x(1)` `->` `x(5) + x(7)`
3. out: `x(5) + x(7)` (!)

Informally the buggy substitution method worked like so:

1. `let q = poly / from_var`
2. `if q == 1 return to_var`

I don't know what definition of this kind of multivariate polynomial division is actually used by BoolePolynomial here, but at a first pass I'd assume `A / B`, where `B` is the single variable `b`, finds quotient `Q` and remainder `R` s.t. `A = B*Q + R` and `R` has a lower degree in terms of the variable `b` than `A`. (Which in GF(2) means degree 0 so there's no `b` in `R`.) Then `Q == 1` tells us `R = A-B`, not that `A=B`!

The code as it was written before #25 had, not withstanding its singleton bug, this implementation for the `Q==1` case: `poly -= from_var; poly +=  to_poly;`. That might be faster. But it seemed conceptually simpler to me to always calculate and add the remainder.

Ironically I added back an `isSingleton` test because if `quotient` is how many `b` we have in `A`, and `A` is a single boolean monomial, and quotient is not 0, then `b*quotient` is that monomial. So we don't have to go find `R` (which holds for any degree of `Q`, not just degree 0).

(This is an area which clearly needs more unit tests and I've contributed one here in the PR.)

This fix also seems to resolve #27!